### PR TITLE
Fix wrong number of advice-remove arguments

### DIFF
--- a/composable.el
+++ b/composable.el
@@ -250,7 +250,7 @@ For each function named foo a function name composable-foo is created."
         (add-hook 'deactivate-mark-hook 'composable--deactivate-mark-hook-handler)
         (advice-add 'set-mark-command :before 'composable--set-mark-command-advice))
     (remove-hook 'deactivate-mark-hook 'composable--deactivate-mark-hook-handler)
-    (advice-remove 'set-mark-command :before 'composable--set-mark-command-advice)))
+    (advice-remove 'set-mark-command 'composable--set-mark-command-advice)))
 
 (provide 'composable)
 


### PR DESCRIPTION
`advice-remove` takes 2 arguments, symbol and function. I got following warning by byte-compiling.

```
In composable-mark-mode:
composable.el:253:6:Warning: advice-remove called with 3 arguments, but accepts only 2
```

See
- https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Named-Functions.html#Advising-Named-Functions
