### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/composable.el
+++ b/composable.el
@@ -5,6 +5,7 @@
 ;; Author: Simon Friis Vindum <simon@vindum.io>
 ;; Keywords: lisp
 ;; Version: 0.0.1
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`advice-add`, `advice-remove`, `set-transient-map` were introduced at Emacs 24.4.
