### PR TITLE
add whole buffer object binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Besides the bindings mentioned below 0-9 are bound to
 | <kbd>a</kbd> | `move-beginning-of-line` |
 | <kbd>f</kbd> | `forward-word` |
 | <kbd>b</kbd> | `backward-word` |
+| <kbd>u</kbd> | `mark-whole-buffer` |
 | <kbd>n</kbd> | `next-line` |
 | <kbd>p</kbd> | `previous-line` |
 | <kbd>l</kbd> | `composable-mark-line` |

--- a/composable.el
+++ b/composable.el
@@ -263,6 +263,7 @@ For each function named foo a function name composable-foo is created."
     ((kbd "e") . move-end-of-line)
     ((kbd "f") . forward-word)
     ((kbd "b") . backward-word)
+    ((kbd "u") . mark-whole-buffer)
     ((kbd "n") . next-line)
     ((kbd "p") . previous-line)
     ((kbd "l") . composable-mark-line)


### PR DESCRIPTION
Just as title says, now there is `B` binding to operate on whole buffer. In case I missed something, just let me know.
