### PR TITLE
Fixed copy issues and improved functionalities.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 - master
+  - Fixed issues with comment commands,
+  - Added which-key integration in `which-key-mode`.
   - Mark commands marks from beginning to end when used inside
     composable-mark-mode. For instance `C-SPC w` marks entire word
   - Properly detect prefix arguments in Emacs >= 25.1

--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ When a prefix argument is specified before a paired movement command
 establish a region. For instance both <kbd>M-w , f</kbd> and <kbd>M-w . f</kbd> will save the
 current word to the kill ring.
 
+The default defined pairs are:
+
+1. forward-word &&  backward-word: To select the current work
+2. move-end-of-line && back-to-indentation: To select the line (without indentation)
+3. next-line && previous-line
+4. forward-paragraph && backward-paragraph
+5. forward-sentence && backward-sentence
+
 ## Mode-line Color indicator
 
 A variable `composable-mode-line-color` is defined to change the

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ line—including the line break. This is because <kbd>l</kbd> marks the
 entire line but due to <kbd>.</kbd> only the end of the marked region
 is used.
 
-Similairly <kbd>C-w h</kbd> will kill one paragraph from beginning to
+Similarly <kbd>C-w h</kbd> will kill one paragraph from beginning to
 end. But <kbd>C-w , h</kbd> will kill one paragraph backwards and
 <kbd>C-w . h</kbd> will kill one paragraph forward.
 
@@ -310,3 +310,20 @@ To disable this feature just add:
 ```
 
 to your config.
+
+## Kill specific options
+
+Composable implements a special version for `copy-region-as-kill`
+called `composable-save-region`. 
+
+By default composable always highlights the copied region
+independently if the region was active before calling the kill command
+or not. This is different to `copy-region-as-kill` which disables the
+region after the copy. But in composable it makes some sense. Any way,
+if the user wants the default behavior he can set:
+
+``` common-lisp
+(setq composable-copy-active-region-highlight nil)
+```
+
+

--- a/composable-mark.el
+++ b/composable-mark.el
@@ -26,6 +26,16 @@
 
 ;;; Code:
 
+(defvar composable--border-point)
+(defvar composable--count)
+
+(defun composable--direction (arg)
+  "Direction of ARG."
+  (let ((n (prefix-numeric-value arg)))
+    (if n
+	(/ n (abs n))
+      1)))
+
 (defun composable-mark-join (arg)
   "Mark the whitespace separating lines.
 Between the line above if ARG is negative otherwise below."
@@ -47,24 +57,22 @@ The movement must mark backwards with negative arguments."
   (let* ((amount (if arg
                      (prefix-numeric-value arg)
                    (if (< (mark t) (point)) -1 1)))
-         (dir (/ amount (abs amount)))
-         (empty-sel (and (region-active-p) (= (mark t) (point)))))
-    (when (or (not (region-active-p))
-              empty-sel)
-      (funcall forward dir)
-      (funcall forward (- dir))
-      (when empty-sel
-        (goto-char
-         (funcall (if (< 0 amount) 'min 'max)
-                  (mark t)
-                  (point)))))
-    (push-mark
-     (save-excursion
-       (when (region-active-p)
-         (goto-char (mark t)))
-       (funcall forward amount)
-       (point))
-     nil t)))
+         (dir (/ amount (abs amount))))
+    (when (= composable--count 1)
+	(progn
+	  (funcall forward dir)
+	  (funcall forward (- dir))
+	  (setq composable--border-point (point-marker))
+	  (set-mark (point))
+
+	  (if (< 0 amount)
+	      (goto-char (min (mark t) (point)))
+	    (goto-char (max (mark t) (point))))
+	  )
+	)
+
+    (funcall forward amount)
+  ))
 
 (defun composable-mark-line (arg)
   "Mark ARG lines.
@@ -83,6 +91,12 @@ Supports negative arguments and repeating."
 Supports negative arguments and repeating."
   (interactive "P")
   (composable--mark-with-forward #'forward-symbol arg))
+
+(defun composable-mark-paragraph (arg)
+  "Mark ARG symbols.
+Supports negative arguments and repeating."
+  (interactive "P")
+  (composable--mark-with-forward #'forward-paragraph arg))
 
 (defun composable--up-list (arg)
   "Up-list ARG times with better quotes support."

--- a/composable-mark.el
+++ b/composable-mark.el
@@ -70,19 +70,19 @@ The movement must mark backwards with negative arguments."
   "Mark ARG lines.
 Supports negative argument and repeating."
   (interactive "P")
-  (composable--mark-with-forward 'forward-line arg))
+  (composable--mark-with-forward #'forward-line arg))
 
 (defun composable-mark-word (arg)
   "Mark ARG words.
 Supports negative arguments and repeating."
   (interactive "P")
-  (composable--mark-with-forward 'forward-word arg))
+  (composable--mark-with-forward #'forward-word arg))
 
 (defun composable-mark-symbol (arg)
   "Mark ARG symbols.
 Supports negative arguments and repeating."
   (interactive "P")
-  (composable--mark-with-forward 'forward-symbol arg))
+  (composable--mark-with-forward #'forward-symbol arg))
 
 (defun composable--up-list (arg)
   "Up-list ARG times with better quotes support."
@@ -94,7 +94,7 @@ Supports negative arguments and repeating."
   "Mark ARG upper lists.
 Supports negative arguments and repeating."
   (interactive "P")
-  (composable--mark-up 'forward-sexp 'composable--up-list arg))
+  (composable--mark-up #'forward-sexp #'composable--up-list arg))
 
 (defun composable--mark-up (forward up arg)
   "Mark a region based on a FORWARD and UP movement and ARG.

--- a/composable.el
+++ b/composable.el
@@ -94,7 +94,7 @@ This can be either a function or any value accepted by
   :type 'color
   :group 'composable)
 
-(defcustom composable-kill-region-highlight nil
+(defcustom composable-copy-active-region-highlight nil
   "Use composable highlight when kilkling preselected region."
   :type 'boolean
   :group 'composable)
@@ -297,7 +297,7 @@ For each function named foo a function name composable-foo is created."
 	 (copy-region-as-kill mark point)
 
 	 (when (or (> composable--count 1)
-		   composable-kill-region-highlight ;; set this to true if you want highlight after coping a region
+		   composable-copy-active-region-highlight ;; set to true if you want highlight active region
 		   composable-object-mode)
 	   (if (marker-position composable--start-point)
 	       (move-overlay composable--overlay
@@ -390,8 +390,7 @@ For each function named foo a function name composable-foo is created."
       (progn
 	(setq composable--overlay (make-overlay 0 0))
 	(overlay-put composable--overlay 'priority 999)
-	(overlay-put composable--overlay 'face 'composable-highlight)
-	)
+	(overlay-put composable--overlay 'face 'composable-highlight))
     (setq composable--overlay nil)
   ))
 

--- a/composable.el
+++ b/composable.el
@@ -114,6 +114,7 @@ specifies and call COMMAND on the region."
   (lambda (arg)
     (interactive "P")
     (cond ((region-active-p)
+	   (setq composable--count 0)
            (call-interactively command))
           (composable-object-mode
            (setq this-command composable-twice-mark)

--- a/composable.el
+++ b/composable.el
@@ -83,10 +83,12 @@
   "Use a custom face for the cursor when in object mode.
 This can be either a function or any value accepted by
 `cursor-type'."
+  :type 'function
   :group 'composable)
 
 (defcustom composable-twice-mark 'composable-mark-line
   "Thing to mark when a composable command is called twice successively."
+  :type 'function
   :group 'composable)
 
 (defcustom composable-mode-line-color "cyan"
@@ -108,7 +110,7 @@ This can be either a function or any value accepted by
 (defvar composable--command-prefix nil)
 (defvar composable--saved-cursor nil)
 (defvar composable--expand nil)
-(defvar composable--which-key-timer nil) 
+(defvar composable--which-key-timer nil)
 
 (defun composable-create-composable (command)
   "Take a function and return it in a composable wrapper.
@@ -388,8 +390,7 @@ For each function named foo a function name composable-foo is created."
 	(setq composable--overlay (make-overlay 0 0))
 	(overlay-put composable--overlay 'priority 999)
 	(overlay-put composable--overlay 'face 'composable-highlight))
-    (setq composable--overlay nil)
-  ))
+    (setq composable--overlay nil)))
 
 (defun composable--deactivate-mark-hook-handler ()
   "Leave object mode when the mark is disabled."

--- a/composable.el
+++ b/composable.el
@@ -106,6 +106,7 @@ This can be either a function or any value accepted by
 (defvar composable--command-prefix nil)
 (defvar composable--saved-cursor nil)
 (defvar composable--expand nil)
+(defvar composable--which-key-timer nil) 
 
 (defun composable-create-composable (command)
   "Take a function and return it in a composable wrapper.
@@ -345,8 +346,9 @@ For each function named foo a function name composable-foo is created."
 	;; which-key
 	(when (and composable-which-keys
 		   (bound-and-true-p which-key-mode))
-	  (setq which-key-persistent-popup t)
-	  (which-key-show-keymap 'composable-object-mode-map t))
+	  (setq composable--which-key-timer
+		(run-with-idle-timer which-key-idle-delay nil
+				     #'which-key-show-keymap 'composable-object-mode-map t)))
 
         (add-hook 'post-command-hook 'composable--post-command-hook-handler)
 	(message "Composable mode: %s" this-command))
@@ -356,9 +358,8 @@ For each function named foo a function name composable-foo is created."
     (setq composable--prefix-arg nil
 	  composable--command nil)
 
-    (when (bound-and-true-p which-key-persistent-popup)
-      (setq which-key-persistent-popup nil)
-      (which-key--hide-popup))
+    (when (bound-and-true-p which-key-mode)
+      (cancel-timer composable--which-key-timer))
 
     (when (or (called-interactively-p 'any)
 	      (not composable-repeat))

--- a/composable.el
+++ b/composable.el
@@ -101,7 +101,7 @@ This can be either a function or any value accepted by
 (defvar composable--command nil)
 (defvar composable--count 0)                 ;; Count the repeated times
 (defvar composable--prefix-arg nil)
-(defvar composable--start-point nil)
+(defvar composable--start-point (make-marker))
 (defvar composable--fn-pairs (make-hash-table :test 'equal))
 (defvar composable--command-prefix nil)
 (defvar composable--saved-cursor nil)
@@ -284,8 +284,10 @@ For each function named foo a function name composable-foo is created."
   (composable-create-composable
    (lambda (mark point)
      (interactive (list (mark) (point)))
-     (let ((o (make-overlay composable--start-point point)))
-
+     (let ((o (make-overlay (if (marker-position composable--start-point)
+				 composable--start-point
+			       mark)
+			     point)))
        (when (and (> composable--count 1)
 		  composable-repeat-copy-save-last)
 	 (setq last-command 'kill-region))

--- a/composable.el
+++ b/composable.el
@@ -120,7 +120,8 @@ The returned function will ask for an object, mark the region it
 specifies and call COMMAND on the region."
   (lambda (arg)
     (interactive "P")
-    (cond ((region-active-p)
+    (cond ((or (region-active-p)
+	       (bound-and-true-p multiple-cursors-mode))
 	   (setq composable--count 0)
            (call-interactively command))
           (composable-object-mode
@@ -304,8 +305,9 @@ For each function named foo a function name composable-foo is created."
 
 	   (when (and (> composable--count 1)
 		      composable-repeat-copy-save-last)
-	     (setq last-command 'kill-region))
-	   (copy-region-as-kill mark point)))))
+	     (setq last-command 'kill-region)))
+
+	 (copy-region-as-kill mark point))))
 
 (defun composable-goto-char (arg char)
   (interactive (list (prefix-numeric-value current-prefix-arg)
@@ -413,7 +415,8 @@ For each function named foo a function name composable-foo is created."
   "Advice for `set-mark-command'.
 Activates composable-object-mode unless ARG is non-nil."
   (unless (or composable-object-mode
-	      arg)
+	      arg
+	      (bound-and-true-p multiple-cursors-mode))
     (setq composable--expand t)
     (composable-object-mode 1)))
 

--- a/composable.el
+++ b/composable.el
@@ -94,13 +94,10 @@ This can be either a function or any value accepted by
   :type 'color
   :group 'composable)
 
-(defcustom composable-copy-active-region-highlight nil
+(defcustom composable-copy-active-region-highlight t
   "Use composable highlight when kilkling preselected region."
   :type 'boolean
   :group 'composable)
-
-(defface easy-kill-selection '((t (:inherit secondary-selection)))
-  "Faced used to highlight kill candidate.")
 
 (defvar composable--saved-mode-line-color nil)
 (defvar composable--command nil)
@@ -287,7 +284,7 @@ For each function named foo a function name composable-foo is created."
   (delete-overlay composable--overlay)
   (remove-hook 'pre-command-hook 'composable--delete-highlight))
 
-(fset 'composable-save-region
+(fset 'composable-copy-region-as-kill
       (composable-create-composable
        (lambda (mark point)
 	 (interactive (list (mark) (point)))
@@ -381,7 +378,7 @@ For each function named foo a function name composable-foo is created."
   :global 1
   :keymap
   `((,(kbd "C-w") . composable-kill-region)
-    (,(kbd "M-w") . composable-save-region)
+    (,(kbd "M-w") . composable-copy-region-as-kill)
     (,(kbd "M-;") . composable-comment-or-uncomment-region)
     (,(kbd "C-x C-u") . composable-upcase-region)
     (,(kbd "C-x C-l") . composable-downcase-region)

--- a/features/composable.feature
+++ b/features/composable.feature
@@ -435,3 +435,39 @@ Feature: composable
       """
       (deep (nested ))
       """
+
+  Scenario: Commenting lines with repeat
+    When I insert:
+    """
+    1. line
+    2. line
+    3. line
+    4. line
+    """
+    And I place the cursor after "2."
+    And I press "M-; l l"
+    Then I should see:
+    """
+    1. line
+    ;; 2. line
+    ;; 3. line
+    4. line
+    """
+
+  Scenario: Kill with goto-char
+    When I insert "first second third forth fifth"
+    And I place the cursor before "second"
+    And I press "C-w c t"
+    Then I should see "first hird forth fifth"
+
+  Scenario: Kill with goto-char repeating
+    When I insert "first second third forth fifth"
+    And I place the cursor before "second"
+    And I press "C-w c t c c"
+    Then I should see "first h"
+
+  Scenario: Kill with goto-char backward
+    When I insert "first second third forth fifth"
+    And I place the cursor after "forth"
+    And I press "C-w - c r"
+    Then I should see "first second third fo fifth"


### PR DESCRIPTION
There were some issues in the previous patch that were fixed with the highlight when copy. 

Added another configuration option for the copy function to avoid highlight after preselected region (keep the original copy-as-kill behaviour).

Modified the which-key integration to use an idle-delay to be more consistent with the which-key behavior.
