### PR TITLE
Fix non-composable `kill-ring-save'

### DIFF
--- a/composable.el
+++ b/composable.el
@@ -284,16 +284,17 @@ For each function named foo a function name composable-foo is created."
   (composable-create-composable
    (lambda (mark point)
      (interactive (list (mark) (point)))
-     (let ((o (make-overlay composable--start-point point)))
-
-       (when (and (> composable--count 1)
-		  composable-repeat-copy-save-last)
-	 (setq last-command 'kill-region))
-       (copy-region-as-kill mark point)
-       (setq composable--overlay o)
-       (overlay-put o 'priority 999)
-       (overlay-put o 'face 'composable-highlight)
-       (add-hook 'pre-command-hook 'composable--delete-highlight)))))
+     (if (null (marker-position composable--start-point))
+         (call-interactively #'kill-ring-save)
+       (let ((o (make-overlay composable--start-point point)))
+         (when (and (> composable--count 1)
+                    composable-repeat-copy-save-last)
+           (setq last-command 'kill-region))
+         (copy-region-as-kill mark point)
+         (setq composable--overlay o)
+         (overlay-put o 'priority 999)
+         (overlay-put o 'face 'composable-highlight)
+         (add-hook 'pre-command-hook 'composable--delete-highlight))))))
 
 (define-minor-mode composable-object-mode
   "Composable mode."


### PR DESCRIPTION
Bug: using `composable-save' resulted in an error when creating a marker.

Steps to reproduce problem:
1. Open a non-empty buffer.
2. Go to the start of the buffer.
3. Hit C-SPC.
4. Hit C-n.
5. Hit M-w.

Result: "let: Marker points into wrong buffer: #<marker in no buffer>"

Expected: Standard "non-composable" Emacs behaviour. i.e. `kill-ring-save'.

Explanation: `composable-save' assumed that `composable--start-point' would be set
to a valid value when hitting M-w; however,
`composable-create-composable' assumes that the command which it's
wrapping will behave correctly when called interactively without
enabling `composable-object-mode'.  Here we check to see whether the
start point was defined (since composable jumps between
`composable-object-mode' and `composable-mark-mode' in this
interaction.)