### PR TITLE
Fix overlay issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test:
 
 plain:
 	$(EMACS) --version
-	$(EMACS) $(LOAD) -f composable-mode
+	$(EMACS) $(LOAD) -f composable-mode -f composable-mark-mode

--- a/composable.el
+++ b/composable.el
@@ -411,7 +411,11 @@ For each function named foo a function name composable-foo is created."
 	(setq composable--overlay (make-overlay 0 0))
 
 	(overlay-put composable--overlay 'priority 999)
-	(overlay-put composable--overlay 'face 'composable-highlight))
+	(overlay-put composable--overlay 'face 'composable-highlight)
+	;; associate the overlay with no specific buffer. Otherwise it
+	;; may be not visible when set for the first time and appear
+	;; visible when not expected.
+	(delete-overlay composable--overlay))
     (setq composable--overlay nil)))
 
 (defun composable--deactivate-mark-hook-handler ()

--- a/features/composable.feature
+++ b/features/composable.feature
@@ -518,3 +518,17 @@ Feature: composable
     And I place the cursor before "third"
     And I press "C-w . l"
     Then I should see "first second "
+
+  Scenario: Composable-mark mode word
+    When I insert "first second third forth fifth"
+    And I place the cursor before "second"
+    And I press "C-SPC w w"
+    And I press "C-w"
+    Then I should see "first  forth fifth"
+
+  Scenario: Composable-mark mode end line
+    When I insert "first second third forth fifth"
+    And I place the cursor before "second"
+    And I press "C-SPC e"
+    And I press "C-w"
+    Then I should see "first "


### PR DESCRIPTION
The first time composable was used the overlay was not visible because it was
associated with a potential different buffer.

So we delete the overlay just after creating it so it is not associated
with any initial buffer when called move-overlay for the first time.